### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - run: npm ci
@@ -27,13 +27,13 @@ jobs:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
           preRelease: ${{ env.IS_PRE_RELEASE }}
-      - name: Publish to Open VSX Registry
-        if: ${{ ! fromJSON(env.IS_PRE_RELEASE) }}
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{ secrets.OVSX_TOKEN }}
-          registryUrl: https://open-vsx.org
-          extensionFile: ${{ steps.publishToVSM.outputs.vsixPath }}
+      #- name: Publish to Open VSX Registry
+      #  if: ${{ ! fromJSON(env.IS_PRE_RELEASE) }}
+      #  uses: HaaLeo/publish-vscode-extension@v1
+      #  with:
+      #    pat: ${{ secrets.OVSX_TOKEN }}
+      #    registryUrl: https://open-vsx.org
+      #    extensionFile: ${{ steps.publishToVSM.outputs.vsixPath }}
       - name: Create draft GitHub Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
To get the publishing workflow working again, it is required to add a secret with the name `VS_MARKETPLACE_TOKEN` in repository settings.

Documentation to generate the token: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token