### PR TITLE
Removed the need for spaces before some keywords and after '$' (one-line python) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.x
+
+* The first stable release targeting Ren'Py 8.3.
+
 ## 2.3.x
 
 * Development of Ren'Py language has moved to the Ren'Py project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "language-renpy",
-  "version": "2.3.10",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "language-renpy",
-      "version": "2.3.10",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "language-renpy",
   "displayName": "Ren'Py Language (8.3+)",
   "description": "Adds rich support for the Ren'Py programming language to Visual Studio Code.",
-  "version": "2.3.10",
+  "version": "2.4.0",
   "publisher": "renpy",
   "license": "MIT",
   "homepage": "https://github.com/renpy/vscode-language-renpy",
@@ -148,7 +148,7 @@
         "runtime": "node",
         "configurationAttributes": {
           "launch": {
-            "required": [ ],
+            "required": [],
             "properties": {
               "command": {
                 "type": "string",
@@ -158,7 +158,7 @@
               "args": {
                 "type": "array",
                 "description": "Args to run Ren'Py with.",
-                "default": [ ]
+                "default": []
               }
             }
           }
@@ -169,7 +169,7 @@
             "request": "launch",
             "name": "Ren'Py: Launch",
             "command": "run",
-            "args": [ ]
+            "args": []
           }
         ],
         "configurationSnippets": [
@@ -181,7 +181,7 @@
               "request": "launch",
               "name": "Ren'Py",
               "command": "run",
-              "args": [ ]
+              "args": []
             }
           }
         ]
@@ -202,7 +202,7 @@
           "args": {
             "type": "array",
             "description": "Args to run Ren'Py with.",
-            "default": [ ]
+            "default": []
           }
         }
       }

--- a/syntaxes/renpy.tmLanguage.json
+++ b/syntaxes/renpy.tmLanguage.json
@@ -821,7 +821,7 @@
       ]
     },
     "one-line-python": {
-      "begin": "(?<=^[ \\t]*)(\\$)(?=[ \\t]|$)",
+      "begin": "(?<=^[ \\t]*)(\\$)",
       "beginCaptures": {
         "1": { "name": "keyword.dollar.sign.renpy" }
       },
@@ -838,7 +838,7 @@
         {
           "name": "meta.say.statement.renpy",
           "contentName": "renpy.meta.say.$1 string.quoted.renpy",
-          "begin": "(?<=^[ \\t]+)(?:([a-zA-Z_]\\w*)\\b|\"([a-zA-Z_]\\w*)\\b\")((?:[ \\t]+(?:@|\\w+))*)?[ \\t]*(\"\"\"|\"|'''|'|```|`)",
+          "begin": "(?<=^[ \\t]*)(?:([a-zA-Z_]\\w*)\\b|\"([a-zA-Z_]\\w*)\\b\")((?:[ \\t]+(?:@|\\w+))*)?[ \\t]*(\"\"\"|\"|'''|'|```|`)",
           "beginCaptures": {
             "1": {
               "name": "renpy.meta.character.$1 variable.other.renpy",
@@ -883,7 +883,7 @@
         {
           "name": "meta.say.narrator.renpy",
           "contentName": "string.quoted.narrator.renpy",
-          "begin": "(?<=^[ \\t]+)(\"\"\"|\"|'''|'|```|`)",
+          "begin": "(?<=^[ \\t]*)(\"\"\"|\"|'''|'|```|`)",
           "beginCaptures": {
             "1": { "name": "string.quoted.renpy punctuation.definition.string.begin.renpy" }
           },
@@ -903,7 +903,7 @@
     "pause": {
       "name": "meta.pause.statement.renpy",
       "contentName": "meta.pause.parameters.renpy",
-      "begin": "(?<=^[ \\t]+)(pause)\\b",
+      "begin": "(?<=^[ \\t]*)(pause)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.pause.renpy" }
       },
@@ -923,7 +923,7 @@
     },
 
     "conditionals": {
-      "begin": "(?<=^[ \\t]+)(if|elif|else|while|for)\\b",
+      "begin": "(?<=^[ \\t]*)(if|elif|else|while|for)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.renpy" }
       },
@@ -1205,7 +1205,7 @@
       }
     },
     "return-statements": {
-      "begin": "(?<=^[ \\t]+)(return)\\b",
+      "begin": "(?<=^[ \\t]*)(return)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.return.renpy" }
       },
@@ -1222,7 +1222,7 @@
     },
     "jump": {
       "name": "meta.jump.statement.renpy",
-      "begin": "(?<=^[ \\t]+)(jump)\\b[ \\t]*",
+      "begin": "(?<=^[ \\t]*)(jump)\\b[ \\t]*",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.jump.renpy" }
       },
@@ -1270,7 +1270,7 @@
     "call": {
       "name": "meta.call.statement.renpy",
       "contentName": "meta.call.arguments.renpy",
-      "begin": "(?<=^[ \\t]+)(call)\\b",
+      "begin": "(?<=^[ \\t]*)(call)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.call.renpy" }
       },
@@ -1315,7 +1315,7 @@
     },
     "menu-option": {
       "contentName": "meta.menu-option.block.renpy",
-      "begin": "(?<=(^[ \\t]+))((?:\".*\")|(?:'.*')|(?:\"\"\".*\"\"\"))(.+)?(:)",
+      "begin": "(?<=(^[ \\t]*))((?:\".*\")|(?:'.*')|(?:\"\"\".*\"\"\"))(.+)?(:)",
       "beginCaptures": {
         "2": {
           "name": "meta.menu-option.renpy",
@@ -1343,7 +1343,7 @@
     },
     "menu-set": {
       "contentName": "meta.embedded.line.python",
-      "begin": "(?<=^[ \\t]+)(set)\\b",
+      "begin": "(?<=^[ \\t]*)(set)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.set.renpy" }
       },


### PR DESCRIPTION
Several keyword were not correctly handled because they needed a space before them. So they were not correctly highlighted when they were at the start of a line.
Also python code on a one-line '$' wasn't correctly working when written as follows: "$test = True"  