### PR TITLE
Fixed unnecessary spaces before some commands or after '$' (one-line python)

### DIFF
--- a/examples/unit_test.rpy
+++ b/examples/unit_test.rpy
@@ -3949,5 +3949,9 @@ if True:
 else
     pass
 s "Hello world"
+while condition:
+    #block of code to run
+for value in variable:
+    pass
 return
 #endregion

--- a/examples/unit_test.rpy
+++ b/examples/unit_test.rpy
@@ -71,7 +71,7 @@
             "Sylvie" "Sure!"
 
             show sylvie green smile at right
-            
+
             "Sylvie" "Did you ever hear Lincoln's famous saying, \"The problem with Internet quotations is that many of them are not genuine.\""
 
             scene bg meadow
@@ -238,7 +238,7 @@
 
                 text _("(click to continue)"):
                     size 18
-        
+
         pause .0
         transform ctc_appear:
             alpha 0.0
@@ -259,7 +259,7 @@
 
         "This is one logical line"
 
-        "Since this line contains a string, it continues 
+        "Since this line contains a string, it continues
         even when the line ends."
 
         $ a = [ "Because of parenthesis, this line also",
@@ -294,14 +294,14 @@
             label .local_name:
                 "..resides a local one."
                 jump .local_name
-            
+
             label local:
             label .local:
             label global_name.local:
             label global_label.local_name.error:
             label .global_label.local_name.error:
                 pass
-            
+
 
         label another_global:
             "Now lets jump inside local label located somewhere else."
@@ -559,7 +559,7 @@
         show lucy mad at right
         with dissolve
 
-        show eileen happy with dissolve at left 
+        show eileen happy with dissolve at left
         show lucy mad at right with dissolve
 
         with None
@@ -611,7 +611,7 @@
             "Drink tea.":
                 $ drank_tea = True
             # spaces test
-            
+
                 $ drank_tea.function(something)
 
                 "I drink the tea, trying not to make a political statement as I do."
@@ -777,7 +777,7 @@
         else:
             jump worst_ending
 
-        if ( points >= 10 
+        if ( points >= 10
             and points >= 5
         ):
             jump best_ending
@@ -1222,7 +1222,7 @@
 
                 This line will be separate. Bork bork bork.
                 """)
-                
+
         screen my_screen:
             frame:
                 style_prefix "pref"
@@ -1239,7 +1239,7 @@
             This line will be separate.
             """)
 
-        
+
 
     #endregion Translation
 
@@ -1583,7 +1583,7 @@
                 @renpy.atl_warper
                 def linear(t):
                     return t
-            
+
             init python:
                 @dataclass
                 class LatLonPair:
@@ -1615,7 +1615,7 @@
             pause
             show eileen happy at headright
             pause
-            
+
     #endregion ATL
 
     #region Matrixcolor
@@ -1987,7 +1987,7 @@
 
                     text who id "who"
                     text what id "what"
-            
+
         screen hello_world():
             tag example
             zorder 1
@@ -2874,7 +2874,7 @@
             vbox:
                 for i in range(10):
                     text "[i]"
-            
+
         screen test:
             vbox:
                 for i in range(10):
@@ -3118,7 +3118,7 @@
             with fade
             window show
 
-            "We reached the meadows just outside our hometown. Autumn was so 
+            "We reached the meadows just outside our hometown. Autumn was so
             beautiful here."
             "When we were children, we often played here."
 
@@ -3586,7 +3586,7 @@
 
     #region Customizing the Keymap
         # see https://www.renpy.org/doc/html/keymap.html
-        
+
         init python:
             config.keymap['dismiss'].append('t')
             config.keymap['dismiss'].remove('K_SPACE')
@@ -3871,14 +3871,14 @@
         return
     label after_load:
         return
-        
+
     label splashscreen:
         return
 
     label before_main_menu:
         return
     label main_menu:
-        
+
         return
     label after_warp:
         return
@@ -3888,7 +3888,7 @@
     # Python statements
     init:
         "Renpy code block"
-        
+
     python:
         renpy.pause(delay)
 
@@ -3932,4 +3932,22 @@
                 """Add an item to the inventory."""
                 self.items.append(item);
                 return
+#endregion
+
+#region no indentation
+label test:
+$no_space = True
+return
+label test_nospacing:
+"character" "hello"
+call test_nospacing
+jump test
+" "
+pause
+if True:
+    pass
+else
+    pass
+s "Hello world"
+return
 #endregion

--- a/syntaxes/renpy.tmLanguage.json
+++ b/syntaxes/renpy.tmLanguage.json
@@ -834,7 +834,7 @@
       ]
     },
     "one-line-python": {
-      "begin": "(?<=^[ \\t]*)(\\$)(?=[ \\t]|$)",
+      "begin": "(?<=^[ \\t]*)(\\$)",
       "beginCaptures": {
         "1": { "name": "keyword.dollar.sign.renpy" }
       },
@@ -851,7 +851,7 @@
         {
           "name": "meta.say.statement.renpy",
           "contentName": "renpy.meta.say.$1 string.quoted.renpy",
-          "begin": "(?<=^[ \\t]+)(?:((?:character\\.)?[a-zA-Z_]\\w*)\\b|\"([a-zA-Z_]\\w*)\\b\")((?:[ \\t]+(?:@|\\w+))*)?(?=[ \\t]*r?(?:\"|'|`))",
+          "begin": "(?<=^[ \\t]*)(?:((?:character\\.)?[a-zA-Z_]\\w*)\\b|\"([a-zA-Z_]\\w*)\\b\")((?:[ \\t]+(?:@|\\w+))*)?(?=[ \\t]*r?(?:\"|'|`))",
           "beginCaptures": {
             "1": {
               "name": "renpy.meta.character.$1 variable.other.renpy",
@@ -893,7 +893,7 @@
         },
         {
           "name": "meta.say.narrator.renpy meta.say.statement.renpy",
-          "begin": "(?<=^[ \\t]+)(?=r?(?:\"|'|`))",
+          "begin": "(?<=^[ \\t]*)(?=r?(?:\"|'|`))",
           "end": "$",
           "patterns": [
             { "include": "#strings" },
@@ -908,7 +908,7 @@
     "pause": {
       "name": "meta.pause.statement.renpy",
       "contentName": "meta.pause.parameters.renpy",
-      "begin": "(?<=^[ \\t]+)(pause)\\b",
+      "begin": "(?<=^[ \\t]*)(pause)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.pause.renpy" }
       },
@@ -928,7 +928,7 @@
     },
 
     "conditionals": {
-      "begin": "(?<=^[ \\t]+)(if|elif|else|while|for)\\b",
+      "begin": "(?<=^[ \\t]*)(if|elif|else|while|for)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.renpy" }
       },
@@ -1399,7 +1399,7 @@
       ]
     },
     "return-statements": {
-      "begin": "(?<=^[ \\t]+)(return)\\b",
+      "begin": "(?<=^[ \\t]*)(return)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.return.renpy" }
       },
@@ -1416,7 +1416,7 @@
     },
     "jump": {
       "name": "meta.jump.statement.renpy",
-      "begin": "(?<=^[ \\t]+)(jump)\\b",
+      "begin": "(?<=^[ \\t]*)(jump)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.jump.renpy" }
       },
@@ -1465,7 +1465,7 @@
     "call": {
       "name": "meta.call.statement.renpy",
       "contentName": "meta.call.arguments.renpy",
-      "begin": "(?<=^[ \\t]+)(call)\\b",
+      "begin": "(?<=^[ \\t]*)(call)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.control.flow.call.renpy" }
       },
@@ -1499,7 +1499,7 @@
     },
     "menu-option": {
       "contentName": "meta.menu-option.block.renpy",
-      "begin": "(?<=(^[ \\t]+))((?:\".*\")|(?:'.*')|(?:\"\"\".*\"\"\"))(.+)?(:)",
+      "begin": "(?<=(^[ \\t]*))((?:\".*\")|(?:'.*')|(?:\"\"\".*\"\"\"))(.+)?(:)",
       "beginCaptures": {
         "2": {
           "name": "meta.menu-option.renpy",
@@ -1527,7 +1527,7 @@
     },
     "menu-set": {
       "contentName": "meta.embedded.line.python",
-      "begin": "(?<=^[ \\t]+)(set)\\b",
+      "begin": "(?<=^[ \\t]*)(set)\\b",
       "beginCaptures": {
         "1": { "name": "keyword.set.renpy" }
       },


### PR DESCRIPTION
Several keyword were not correctly handled because they needed a space before them. So they were not correctly highlighted when they were at the start of a line.
Also python code on a one-line '$' wasn't correctly working when written as follows: "$test = True"