### PR TITLE
Develop Use a child process for debugging instead of a terminal #478 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ out
 dist
 *.vsix
 dist/*
+/examples/**/*.rpyc
+/examples/errors.txt
+/examples/log.txt


### PR DESCRIPTION
Was originally created to fix #388 and #390
But it looks like those issues were fixed and the problems just persisted in the debugger.

This PR makes use of that work in the debugger as well

It also looks like the `run` command was broken for the example project, because it expected the top level directory to end in `/game`, which isn't a requirement for the Ren'Py executable.
Removed the check and it works fine on the top level