### PR TITLE
fix: add precommit npm task to improve compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-npx lint-staged
+npm run precommit

--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "prepare": "husky install",
+    "prepare": "husky",
     "package": "webpack --mode production --devtool hidden-source-map",
     "build": "webpack --mode development",
     "build:release": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -326,7 +326,8 @@
     "lint": "eslint -c eslint.config.mjs",
     "vsce:package": "vsce package -o language-renpy.vsix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "precommit": "lint-staged"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION

This pull request updates the pre-commit workflow to use a custom npm script instead of calling `lint-staged` directly. 

[View all changes](https://github.com/renpy/vscode-language-renpy/compare/afb665f~1..6423864)

### Summary of changes

- [`afb665f`](https://github.com/renpy/vscode-language-renpy/pull/512/commits/afb665f499eca4935046f2c33e8f3f6dea9877e3 "View commit \"afb665f\" details") chore: fix `prepare` script for husky v9
- [`6423864`](https://github.com/renpy/vscode-language-renpy/pull/512/commits/64238648a8144b75f8fcc2c0b2a57fb808d28475 "View commit \"6423864\" details") fix: add `precommit` npm task to improve compatibility

Fixes #511.